### PR TITLE
Update `getRoot` calls to `getPath('pub')`

### DIFF
--- a/Block/Slider.php
+++ b/Block/Slider.php
@@ -76,7 +76,7 @@ class Slider extends \Magento\Framework\View\Element\Template {
 		return $this->_ids;
 	}
 	public function hasImage(\SY\Slider\Model\Item $item){
-		if($item->getData('image') && is_file($this->_directory->getRoot().$item->getData('image'))){
+		if($item->getData('image') && is_file($this->_directory->getPath('pub').$item->getData('image'))){
 			return true;
 		}
 	}

--- a/Controller/Adminhtml/Items/Save.php
+++ b/Controller/Adminhtml/Items/Save.php
@@ -46,13 +46,13 @@ class Save extends Action {
 				);
 				$uploader->setAllowCreateFolders(true);
 				$uploader->setAllowedExtensions(['jpeg','jpg','png']);
-				if ($uploader->save($directory->getRoot().'/media/slider/'.$model->getId().'/')) {
+				if ($uploader->save($directory->getPath('pub').'/media/slider/'.$model->getId().'/')) {
 					$filename = $uploader->getUploadedFileName();
 					$model->setData('image', '/media/slider/'.$model->getId().'/'.$filename);
 					try {
 						$model->save();
 						if($image){
-							@unlink($directory->getRoot().$image);
+							@unlink($directory->getPath('pub').$image);
 						}
 					} catch (\Exception $e) {
 						$this->messageManager->addException($e, $e->getMessage());

--- a/Model/Item.php
+++ b/Model/Item.php
@@ -17,7 +17,7 @@ class Item extends AbstractModel {
 		$directory = $objectManager->get('\Magento\Framework\Filesystem\DirectoryList');
 		$io = $objectManager->get('Magento\Framework\Filesystem\Io\File');
 		try {
-			$io->rmdir($directory->getRoot().'/media/slider/'.$this->getData('id').'/', true);
+			$io->rmdir($directory->getPath('pub').'/media/slider/'.$this->getData('id').'/', true);
 		} catch (\Exception $e) {}
 		parent::afterDelete();
 	}


### PR DESCRIPTION
At the moment when I upload a slider image, it uploads to `/magento-install/media/slider/...`, which is outside of the public directory.

Changing the attached `getRoot` calls to `getPath('pub')` instead makes it point at the `/magento-install/pub/media/slider/...` directory, which is where they should be.